### PR TITLE
Slight improvements to the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(ctbench)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
+link_libraries(stdc++fs)
 
 option(CTBENCH_ENABLE_TESTING "Enable testing for ctbench components." OFF)
 

--- a/grapher/CMakeLists.txt
+++ b/grapher/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(LLVM REQUIRED CONFIG)
 llvm_map_components_to_libnames(llvm_libs support)
 include_directories(${LLVM_INCLUDE_DIRS})
 link_libraries(${llvm_libs})
+# LLVM libraries are compiled without RTTI
+add_compile_options(-fno-rtti)
 
 # External libraries
 include(cmake/external_libraries.cmake)

--- a/grapher/cmake/external_libraries.cmake
+++ b/grapher/cmake/external_libraries.cmake
@@ -12,7 +12,8 @@ set(JSON_CI OFF)
 
 FetchContent_Declare(json_content
   GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.9.1)
+  GIT_TAG v3.9.1
+  GIT_SHALLOW TRUE)
 
 FetchContent_MakeAvailable(json_content)
 
@@ -23,7 +24,8 @@ link_libraries(nlohmann_json::nlohmann_json)
 
 FetchContent_Declare(sciplot_content
   GIT_REPOSITORY https://github.com/sciplot/sciplot.git
-  GIT_TAG master)
+  GIT_TAG master
+  GIT_SHALLOW TRUE)
 
 FetchContent_GetProperties(sciplot_content)
 if(NOT sciplot_content_POPULATED)


### PR DESCRIPTION
Here are a few fixes to the issues I encountered when building the project:
  - nlohmann's json library has a quite huge repository, since the goal is not to make changes to the dependencies it's probably fine to shallow clone them.
  - when using gcc/clang with an (old?) install of libstd++ (shipped with gcc 8), adding `stdc++fs` is necessary for the project to link properly. I'm not sure if it's still needed in more recent versions.
  - when compiling projects linking with LLVM, I think `-fno-rtti` is necessary because LLVM builds without RTTI.