### PR TITLE
Ubuntu CI fix

### DIFF
--- a/cmake/ctbench-compile-opts.cmake
+++ b/cmake/ctbench-compile-opts.cmake
@@ -15,4 +15,6 @@ target_compile_options(
             -flto
             -fPIC)
 
+target_link_options(ctbench-compile-opts INTERFACE -flto)
+
 target_compile_features(ctbench-compile-opts INTERFACE cxx_std_20)

--- a/grapher/cmake/grapher-target.cmake
+++ b/grapher/cmake/grapher-target.cmake
@@ -10,5 +10,4 @@ target_link_libraries(
   grapher PUBLIC ctbench-compile-opts nlohmann_json::nlohmann_json
   sciplot::sciplot fmt::fmt stdc++fs tbb ${llvm_libs})
 
-target_compile_options(grapher PUBLIC -DJSON_NOEXCEPTION -march=native -flto)
-target_link_options(grapher PUBLIC -flto)
+target_compile_options(grapher PUBLIC -DJSON_NOEXCEPTION)


### PR DESCRIPTION
Added missing `-flto` link option and removed redundant link and compile options for grapher library target