### PR TITLE
Replace std::experimental with std::, add gnuplot to CI packages, bump patch

### DIFF
--- a/.github/actions/run-tests-archlinux/Dockerfile
+++ b/.github/actions/run-tests-archlinux/Dockerfile
@@ -14,6 +14,7 @@ RUN pacman -S --noconfirm \
   curl \
   fmt \
   git \
+  gnuplot \
   llvm \
   llvm-libs \
   ninja \

--- a/.github/actions/run-tests-ubuntu/Dockerfile
+++ b/.github/actions/run-tests-ubuntu/Dockerfile
@@ -15,6 +15,7 @@ RUN apt install -y \
   cmake \
   curl \
   git \
+  gnuplot-nox \
   libboost-all-dev \
   libclang-dev \
   libfmt-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.25)
-project(ctbench VERSION 1.3.2)
+project(ctbench VERSION 1.3.3)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -1,7 +1,7 @@
 # Documentation options
 set(DOXYGEN_EXTRACT_ALL YES)
 set(DOXYGEN_GENERATE_TREEVIEW YES)
-set(DOXYGEN_EXCLUDE_PATTERNS */build/* */tests/* */build-docs/* paper.md)
+set(DOXYGEN_EXCLUDE_PATTERNS */build/* */tests/* */build-docs/* */example/* paper.md)
 set(DOXYGEN_USE_MDFILE_AS_MAINPAGE ${CMAKE_SOURCE_DIR}/readme.md)
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_SOURCE_DIR})
 set(DOXYGEN_DOT_TRANSPARENT YES)

--- a/grapher/include/grapher/utils/error.hpp
+++ b/grapher/include/grapher/utils/error.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <cstdlib>
-#include <experimental/source_location>
 #include <source_location>
 #include <string_view>
 

--- a/grapher/include/grapher/utils/error.hpp
+++ b/grapher/include/grapher/utils/error.hpp
@@ -30,8 +30,7 @@ inline std::string to_string(error_level_t error_level) {
 /// Prints a warning
 inline void warn(std::string_view explain,
                  error_level_t error_level = warning_v,
-                 std::experimental::source_location loc =
-                     std::experimental::source_location::current()) {
+                 std::source_location loc = std::source_location::current()) {
   llvm::errs() << fmt::format(
       "[{}] {}:{}:{} ({}) - {}\n", to_string(error_level), loc.file_name(),
       loc.line(), loc.column(), loc.function_name(), explain);
@@ -42,8 +41,7 @@ inline void warn(std::string_view explain,
 /// Condition value is then returned (useful for warnings).
 inline bool check(bool condition, std::string_view explain,
                   error_level_t error_level = error_v, int err_code = -1,
-                  std::experimental::source_location loc =
-                      std::experimental::source_location::current()) {
+                  std::source_location loc = std::source_location::current()) {
   if (!condition) {
     warn(explain, error_level, loc);
     if (error_level == error_v) {

--- a/grapher/include/grapher/utils/json.hpp
+++ b/grapher/include/grapher/utils/json.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <experimental/source_location>
 #include <optional>
+#include <source_location>
 #include <string>
 #include <type_traits>
 

--- a/grapher/include/grapher/utils/json.hpp
+++ b/grapher/include/grapher/utils/json.hpp
@@ -40,8 +40,7 @@ field_loc_to_string(grapher::json_t::json_pointer const &json_ptr) {
 template <typename LocType>
 inline grapher::json_t::const_reference
 get_as_json(grapher::json_t const &object, LocType const &field_location,
-            const std::experimental::source_location loc =
-                std::experimental::source_location::current()) {
+            const std::source_location loc = std::source_location::current()) {
   std::string const field_location_str = field_loc_to_string(field_location);
 
   check(object.contains(field_location),
@@ -55,8 +54,7 @@ get_as_json(grapher::json_t const &object, LocType const &field_location,
 template <typename ReferenceType, typename LocType>
 inline ReferenceType
 get_as_ref(grapher::json_t const &object, LocType const &field_location,
-           const std::experimental::source_location loc =
-               std::experimental::source_location::current()) {
+           const std::source_location loc = std::source_location::current()) {
 
   using ValueType = std::decay_t<ReferenceType>;
 


### PR DESCRIPTION
- Replacing std::experimental with std:: does not break compatibility with Arch and Ubuntu so they were removed, hoping this could fix compilation errors on MacOS via vcpkg. 
- Gnuplot was added to CI packages to make sure gnuplot calls from Sciplot generate no errors. 
- Patch number was bumped.