### PR TITLE
Add missing include

### DIFF
--- a/grapher/lib/grapher/utils/cli.cpp
+++ b/grapher/lib/grapher/utils/cli.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 #include <llvm/Support/raw_ostream.h>
 


### PR DESCRIPTION
I got the following error on Apple Clang 15:

```
[1/17] /Library/Developer/CommandLineTools/usr/bin/c++  -I/Users/vagrant/Data/buildtrees/ctbench/src/v1.3.3-f96a0799ba.clean/grapher/include -isystem /Users/vagrant/Data/installed/x64-osx/include -fPIC -g -std=gnu++20 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.0.sdk -DJSON_NOEXCEPTION -Wall -Wextra -Werror -Wnull-dereference -Wold-style-cast -Wdouble-promotion -Wshadow -march=native -fno-rtti -flto -fPIC -MD -MT grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o -MF grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o.d -o grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o -c /Users/vagrant/Data/buildtrees/ctbench/src/v1.3.3-f96a0799ba.clean/grapher/lib/grapher/utils/cli.cpp
FAILED: grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o 
/Library/Developer/CommandLineTools/usr/bin/c++  -I/Users/vagrant/Data/buildtrees/ctbench/src/v1.3.3-f96a0799ba.clean/grapher/include -isystem /Users/vagrant/Data/installed/x64-osx/include -fPIC -g -std=gnu++20 -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.0.sdk -DJSON_NOEXCEPTION -Wall -Wextra -Werror -Wnull-dereference -Wold-style-cast -Wdouble-promotion -Wshadow -march=native -fno-rtti -flto -fPIC -MD -MT grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o -MF grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o.d -o grapher/CMakeFiles/grapher.dir/lib/grapher/utils/cli.cpp.o -c /Users/vagrant/Data/buildtrees/ctbench/src/v1.3.3-f96a0799ba.clean/grapher/lib/grapher/utils/cli.cpp
/Users/vagrant/Data/buildtrees/ctbench/src/v1.3.3-f96a0799ba.clean/grapher/lib/grapher/utils/cli.cpp:40:28: error: implicit instantiation of undefined template 'std::basic_istringstream<char>'
        std::istringstream iss(entry_dir.path().filename().stem());
                           ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/iosfwd:128:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_istringstream;
                               ^
1 error generated.
```

This is caused by a missing include of sstream