### PR TITLE
Refactored compare_by, small change on standalone example

### DIFF
--- a/example/compare-all.json
+++ b/example/compare-all.json
@@ -4,6 +4,7 @@
   "x_label": "Benchmark size factor",
   "y_label": "Time (µs)",
   "draw_average": true,
+  "draw_median": false,
   "demangle": false,
   "draw_points": false,
   "width": 800,

--- a/grapher/lib/grapher/plotters/compare_by.cpp
+++ b/grapher/lib/grapher/plotters/compare_by.cpp
@@ -74,6 +74,7 @@ struct generate_plot_parameters_t {
   bool draw_points;
   bool draw_median;
   bool demangle;
+  grapher::json_t const &plotter_config;
 };
 
 // =============================================================================
@@ -229,7 +230,8 @@ get_plotgen_parameters(grapher::json_t const &config,
           .average_error_bars = config.value("average_error_bars", false),
           .draw_points = config.value("draw_points", true),
           .draw_median = config.value("draw_median", true),
-          .demangle = config.value("demangle", true)};
+          .demangle = config.value("demangle", true),
+          .plotter_config = config};
 }
 
 grapher::json_t plotter_compare_by_t::get_default_config() const {


### PR DESCRIPTION
- The `compare_by` plotter used to be a monolithic mess so it was rewritten into something more modular, maintainable, and testable.
- The `compare-all.json` config in the standalone example used to draw median as well as average curves, it was changed to make the resulting graph cleaner.