### PR TITLE
Fix build with Boost 1.88.0

### DIFF
--- a/compiler-launcher/compiler-launcher.cpp
+++ b/compiler-launcher/compiler-launcher.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <string_view>
 
-#include <boost/process.hpp>
+#include <boost/process/v1/system.hpp>
 
 #include <nlohmann/json.hpp>
 
@@ -55,7 +55,7 @@ inline int get_timetrace_file(std::filesystem::path const time_trace_file_dest,
   using exec_clock_t = ch::steady_clock;
 
   exec_clock_t::time_point const exec_t0 = exec_clock_t::now();
-  int const exit_code = boost::process::system(command_args);
+  int const exit_code = boost::process::v1::system(command_args);
   exec_clock_t::time_point const exec_t1 = exec_clock_t::now();
 
   // Check child exit code


### PR DESCRIPTION
Starting with Boost 1.88.0, Boost.Process included the v2 implementation by default instead of v1. This PR fixes a bug when building with the new Boost version.