### PR TITLE
Fix compatibility with fmt 12.2.0

### DIFF
--- a/compiler-launcher/compiler-launcher.cpp
+++ b/compiler-launcher/compiler-launcher.cpp
@@ -26,7 +26,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 /// Starts a process and returns its PID.
 int start_process(std::vector<std::string> const &command_args) {

--- a/grapher/include/grapher/utils/error.hpp
+++ b/grapher/include/grapher/utils/error.hpp
@@ -7,7 +7,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace grapher {
 

--- a/grapher/include/grapher/utils/json.hpp
+++ b/grapher/include/grapher/utils/json.hpp
@@ -7,7 +7,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <sciplot/sciplot.hpp>
 

--- a/grapher/lib/grapher/plotters/compare.cpp
+++ b/grapher/lib/grapher/plotters/compare.cpp
@@ -5,7 +5,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <nlohmann/json.hpp>
 

--- a/grapher/lib/grapher/plotters/compare_by.cpp
+++ b/grapher/lib/grapher/plotters/compare_by.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <boost/container/small_vector.hpp>
 

--- a/grapher/lib/grapher/plotters/stack.cpp
+++ b/grapher/lib/grapher/plotters/stack.cpp
@@ -4,7 +4,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <sciplot/Plot2D.hpp>
 #include <sciplot/sciplot.hpp>

--- a/grapher/lib/grapher/predicates.cpp
+++ b/grapher/lib/grapher/predicates.cpp
@@ -5,7 +5,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <grapher/core.hpp>
 #include <grapher/predicates.hpp>

--- a/grapher/lib/grapher/utils/cli.cpp
+++ b/grapher/lib/grapher/utils/cli.cpp
@@ -5,7 +5,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <grapher/utils/cli.hpp>
 #include <grapher/utils/error.hpp>


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.